### PR TITLE
Release v2.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   # Enable version updates for nuget 
   — package-ecosystem: "nuget"
   # Look for NuGet dependency info from the `root` directory
-  directory: "Acolyte.NET/"
+  directory: "/Acolyte.NET/"
   # Check the nuget registry for updates every day (weekdays) schedule: 
   interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates: 
   # Enable version updates for nuget 
   — package-ecosystem: "nuget"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates: 
+  # Enable version updates for nuget 
+  — package-ecosystem: "nuget"
+  # Look for NuGet dependency info from the `root` directory
+  directory: "Acolyte.NET/"
+  # Check the nuget registry for updates every day (weekdays) schedule: 
+  interval: "daily"

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Acolyte.CSharp.csproj
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Acolyte.CSharp.csproj
@@ -22,9 +22,9 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Vasar007/Acolyte.NET.git</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0</Version>
     <PackageId>Acolyte.CSharp</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Vasar007/Acolyte.NET</PackageProjectUrl>

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Acolyte.CSharp.csproj
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Acolyte.CSharp.csproj
@@ -42,6 +42,10 @@
     <NoWarn>1701;1702;CS1591</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <AssemblyTitle>Acolyte.CSharp .NET Standard 2.0</AssemblyTitle>
     <DefineConstants>NETSTANDARD2_0</DefineConstants>

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Collections/AsyncEnumerableExtensions.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Collections/AsyncEnumerableExtensions.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿#if NETSTANDARD2_1
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Acolyte.Assertions;
 
 namespace Acolyte.Collections
 {
-#if NETSTANDARD2_1
     /// <summary>
     /// Contains useful methods to work with asynchronous enumerable items.
     /// </summary>
@@ -43,5 +44,6 @@ namespace Acolyte.Collections
             return result;
         }
     }
-#endif
 }
+
+#endif

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Collections/EnumerableExtensions.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Collections/EnumerableExtensions.cs
@@ -705,7 +705,7 @@ namespace Acolyte.Collections
             source.ThrowIfNull(nameof(source));
             comparer ??= Comparer<TSource>.Default;
 
-            TSource minValue = default;
+            TSource? minValue = default;
             if (minValue is null)
             {
                 foreach (TSource x in source)

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/FormatString.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/FormatString.cs
@@ -44,11 +44,7 @@ namespace Acolyte.Common
         /// <inheritdoc />
         public override int GetHashCode()
         {
-#if NETSTANDARD2_1
             return System.HashCode.Combine(Value);
-#else
-            return Acolyte.Common.HashCode.Combine(Value);
-#endif
         }
 
         /// <inheritdoc />

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/HashCode.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/HashCode.cs
@@ -14,6 +14,8 @@ namespace Acolyte.Common
     /// <see href="https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode" />
     /// <see href="https://rehansaeed.com/gethashcode-made-easy/" />
     /// </remarks>
+    [Obsolete("Use System.HashCode from package Microsoft.Bcl.HashCode.", error: false)]
+    // TODO: replace this class with static helper for System.HashCode.
     public readonly struct HashCode : IEquatable<HashCode>
     {
         /// <summary>

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/HashCode.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/HashCode.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿#if NETSTANDARD2_0
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Acolyte.Common
 {
-#if NETSTANDARD2_0
     /// <summary>
     /// A hash code used to help with implementing <see cref="object.GetHashCode()" />.
     /// If you can use <see href="https://docs.microsoft.com/en-us/dotnet/api/system.hashcode" />,
@@ -468,5 +469,6 @@ namespace Acolyte.Common
             return temp;
         }
     }
-#endif
 }
+
+#endif

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Option.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Option.cs
@@ -98,11 +98,7 @@ namespace Acolyte.Common
         {
             return !HasValue
                ? 0
-#if NETSTANDARD2_1
                : System.HashCode.Combine(_value);
-#else
-               : Acolyte.Common.HashCode.Combine(_value);
-#endif
         }
 
         #endregion

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Reasonable.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Reasonable.cs
@@ -59,11 +59,7 @@ namespace Acolyte.Common
         /// <inheritdoc />
         public override int GetHashCode()
         {
-#if NETSTANDARD2_1
             return System.HashCode.Combine(Value, Reason);
-#else
-            return Acolyte.Common.HashCode.Combine(Value, Reason);
-#endif
         }
 
         /// <inheritdoc />

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Result.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Common/Result.cs
@@ -57,14 +57,10 @@ namespace Acolyte.Common
         public override int GetHashCode()
         {
             return IsSuccess
-#if NETSTANDARD2_1
                 ? System.HashCode.Combine(_ok)
                 : System.HashCode.Combine(_error);
-#else
-                ? Acolyte.Common.HashCode.Combine(_ok)
-                : Acolyte.Common.HashCode.Combine(_error);
-#endif
         }
+
         #endregion
 
         #region IEquatable<Result<TOk, TError>> Implementation

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Functions/IncrementalKeyGenerator.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Functions/IncrementalKeyGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Acolyte.Common;
+﻿using Acolyte.Threading;
 
 namespace Acolyte.Functions
 {

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Threading/CounterInt32.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Threading/CounterInt32.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 
-namespace Acolyte.Common
+namespace Acolyte.Threading
 {
     public sealed class CounterInt32
     {

--- a/Acolyte.NET/Libraries/Acolyte.CSharp/Threading/CounterInt64.cs
+++ b/Acolyte.NET/Libraries/Acolyte.CSharp/Threading/CounterInt64.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 
-namespace Acolyte.Common
+namespace Acolyte.Threading
 {
     public sealed class CounterInt64
     {

--- a/Acolyte.NET/Libraries/Acolyte.FSharp/Acolyte.FSharp.fsproj
+++ b/Acolyte.NET/Libraries/Acolyte.FSharp/Acolyte.FSharp.fsproj
@@ -22,9 +22,9 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Vasar007/Acolyte.NET.git</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0</Version>
     <PackageId>Acolyte.FSharp</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Vasar007/Acolyte.NET</PackageProjectUrl>

--- a/Acolyte.NET/Libraries/Acolyte.NET/Acolyte.NET.csproj
+++ b/Acolyte.NET/Libraries/Acolyte.NET/Acolyte.NET.csproj
@@ -22,9 +22,9 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Vasar007/Acolyte.NET.git</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.0</Version>
     <PackageId>Acolyte.NET</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Vasar007/Acolyte.NET</PackageProjectUrl>

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
@@ -116,12 +116,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void FirstOrDefault_ForCollectionWithSomeItems_ShouldReturnFirstItem(int count)
         {
             // Arrange.
@@ -136,12 +136,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnFirstItem(
             int count)
         {
@@ -159,12 +159,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
@@ -116,12 +116,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void FirstOrDefault_ForCollectionWithSomeItems_ShouldReturnFirstItem(int count)
         {
             // Arrange.
@@ -136,12 +136,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnFirstItem(
             int count)
         {
@@ -159,12 +159,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {
@@ -241,7 +241,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             const int count = 2;
             var explosiveCollection = ExplosiveCollection.Create(
                 TestDataCreator.CreateRandomInt32List(count),
-                explosiveIndex: Constants.FirstIndex + 1
+                explosiveIndex: Common.Constants.FirstIndex + 1
             );
             int expectedValue = explosiveCollection.First();
 
@@ -258,7 +258,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             // Do not use random because we should find exactly second item.
-            int expectedIndex = Constants.FirstIndex + 1;
+            int expectedIndex = Common.Constants.FirstIndex + 1;
             IReadOnlyList<int> collection = new[] { 1, 2, 3, 4 };
             var explosiveCollection = ExplosiveCollection.Create(
                 collection, explosiveIndex: expectedIndex + 1

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/FirstOrDefaultTests.cs
@@ -116,12 +116,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void FirstOrDefault_ForCollectionWithSomeItems_ShouldReturnFirstItem(int count)
         {
             // Arrange.
@@ -136,12 +136,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnFirstItem(
             int count)
         {
@@ -159,12 +159,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void FirstOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
@@ -171,12 +171,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -194,12 +194,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -217,12 +217,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -242,12 +242,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(int count)
         {
             // Arrange.
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
@@ -86,7 +86,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> emptyCollection = Enumerable.Empty<int>();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = emptyCollection.IndexOf(_ => default);
@@ -100,7 +100,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> emptyCollection = Enumerable.Empty<int>();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = emptyCollection.IndexOf(default(int));
@@ -114,7 +114,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> emptyCollection = Enumerable.Empty<int>();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = emptyCollection.IndexOf(default, EqualityComparer<int>.Default);
@@ -128,7 +128,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IReadOnlyList<int> predefinedCollection = new[] { 1, 2, 3 };
-            int expectedIndex = Constants.FirstIndex + 1;
+            int expectedIndex = Common.Constants.FirstIndex + 1;
             int expectedItem = predefinedCollection[expectedIndex];
 
             // Act.
@@ -143,7 +143,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IReadOnlyList<int> predefinedCollection = new[] { 1, 2, 3 };
-            int expectedIndex = Constants.FirstIndex + 1;
+            int expectedIndex = Common.Constants.FirstIndex + 1;
             int expectedItem = predefinedCollection[expectedIndex];
 
             // Act.
@@ -158,7 +158,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IReadOnlyList<int> predefinedCollection = new[] { 1, 2, 3 };
-            int expectedIndex = Constants.FirstIndex + 1;
+            int expectedIndex = Common.Constants.FirstIndex + 1;
             int expectedItem = predefinedCollection[expectedIndex];
 
             // Act.
@@ -171,12 +171,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -194,12 +194,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -217,12 +217,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -242,17 +242,17 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(int count)
         {
             // Arrange.
             IEnumerable<int> collectionWithSomeItems = TestDataCreator.CreateRandomInt32List(count);
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithSomeItems.IndexOf(_ => false);
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {
@@ -275,7 +275,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             IEnumerable<int?> collectionWithSomeItems = TestDataCreator
                 .CreateRandomInt32List(count)
                 .ToNullable();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithSomeItems.IndexOf((int?) null);
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {
@@ -298,7 +298,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             IEnumerable<int?> collectionWithSomeItems = TestDataCreator
                  .CreateRandomInt32List(count)
                  .ToNullable();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithSomeItems.IndexOf(
@@ -369,7 +369,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             int count = TestDataCreator.GetRandomCountNumber();
             IEnumerable<int> collectionWithRandomSize =
                 TestDataCreator.CreateRandomInt32List(count);
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithRandomSize.IndexOf(_ => false);
@@ -386,7 +386,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             IEnumerable<int?> collectionWithRandomSize = TestDataCreator
                .CreateRandomInt32List(count)
                .ToNullable();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithRandomSize.IndexOf((int?) null);
@@ -403,7 +403,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             IEnumerable<int?> collectionWithRandomSize = TestDataCreator
                 .CreateRandomInt32List(count)
                 .ToNullable();
-            int expectedIndex = Constants.NotFoundIndex;
+            int expectedIndex = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = collectionWithRandomSize.IndexOf(
@@ -421,7 +421,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Do not use random because we should find exactly second item (2).
             IReadOnlyList<int> collection = new[] { 1, 2, 2, 2 };
             var explosiveCollection = ExplosiveCollection.Create(
-                collection, explosiveIndex: Constants.FirstIndex + 2
+                collection, explosiveIndex: Common.Constants.FirstIndex + 2
             );
             int expectedValue = explosiveCollection.Skip(1).First();
             const int expectedIndex = 1;
@@ -440,7 +440,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Arrange.
             IReadOnlyList<int> collection = new[] { 1, 2, 3, 4 };
             var explosiveCollection = ExplosiveCollection.CreateNotExplosive(collection);
-            int expectedValue = Constants.NotFoundIndex;
+            int expectedValue = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = explosiveCollection.IndexOf(_ => false);
@@ -457,7 +457,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Do not use random because we should find exactly second item (2).
             IReadOnlyList<int> collection = new[] { 1, 2, 2, 2 };
             var explosiveCollection = ExplosiveCollection.Create(
-                collection, explosiveIndex: Constants.FirstIndex + 2
+                collection, explosiveIndex: Common.Constants.FirstIndex + 2
             );
             int value = explosiveCollection.Skip(1).First();
             const int expectedIndex = 1;
@@ -476,7 +476,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Arrange.
             IReadOnlyList<int> collection = new[] { 1, 2, 3, 4 };
             var explosiveCollection = ExplosiveCollection.CreateNotExplosive(collection);
-            int expectedValue = Constants.NotFoundIndex;
+            int expectedValue = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = explosiveCollection.IndexOf(value: 0);
@@ -493,7 +493,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Do not use random because we should find exactly second item (2).
             IReadOnlyList<int> collection = new[] { 1, 2, 2, 2 };
             var explosiveCollection = ExplosiveCollection.Create(
-                collection, explosiveIndex: Constants.FirstIndex + 2
+                collection, explosiveIndex: Common.Constants.FirstIndex + 2
             );
             int value = explosiveCollection.Skip(1).First();
             const int expectedIndex = 1;
@@ -514,7 +514,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Arrange.
             IReadOnlyList<int> collection = new[] { 1, 2, 3, 4 };
             var explosiveCollection = ExplosiveCollection.CreateNotExplosive(collection);
-            int expectedValue = Constants.NotFoundIndex;
+            int expectedValue = Common.Constants.NotFoundIndex;
 
             // Act.
             int actualIndex = explosiveCollection.IndexOf(value: 0, EqualityComparer<int>.Default);

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IndexOfTests.cs
@@ -171,12 +171,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -194,12 +194,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -217,12 +217,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnIndexOfRandomlySelectedItem(
             int count)
         {
@@ -242,12 +242,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(int count)
         {
             // Arrange.
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_Item_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IndexOf_ItemWithComparer_ForCollectionWithSomeItems_ShouldReturnNotFoundIndex(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
@@ -44,12 +44,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void IsNullOrEmpty_ForCollectionWithSomeItems_ShouldReturnFalse(int count)
         {
             // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
@@ -44,12 +44,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void IsNullOrEmpty_ForCollectionWithSomeItems_ShouldReturnFalse(int count)
         {
             // Arrange.
@@ -97,7 +97,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             const int count = 2;
             var explosiveCollection = ExplosiveCollection.Create(
                 TestDataCreator.CreateRandomInt32List(count),
-                explosiveIndex: Constants.FirstIndex + 1
+                explosiveIndex: Common.Constants.FirstIndex + 1
             );
             bool expectedResult = !explosiveCollection.Any();
 

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/IsNullOrEmptyTests.cs
@@ -44,12 +44,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void IsNullOrEmpty_ForCollectionWithSomeItems_ShouldReturnFalse(int count)
         {
             // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
@@ -115,12 +115,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void LastOrDefault_ForCollectionWithSomeItems_ShouldReturnLastItem(int count)
         {
             // Arrange.
@@ -135,12 +135,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnLastItem(
             int count)
         {
@@ -158,12 +158,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
@@ -115,12 +115,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void LastOrDefault_ForCollectionWithSomeItems_ShouldReturnLastItem(int count)
         {
             // Arrange.
@@ -135,12 +135,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnLastItem(
             int count)
         {
@@ -158,12 +158,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/LastOrDefaultTests.cs
@@ -115,12 +115,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void LastOrDefault_ForCollectionWithSomeItems_ShouldReturnLastItem(int count)
         {
             // Arrange.
@@ -135,12 +135,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnLastItem(
             int count)
         {
@@ -158,12 +158,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void LastOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
@@ -214,12 +214,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
     int count)
         {
@@ -237,12 +237,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
             int count)
         {
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
@@ -214,12 +214,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
     int count)
         {
@@ -237,12 +237,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
             int count)
         {
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxByKeyTests.cs
@@ -214,12 +214,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
     int count)
         {
@@ -237,12 +237,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMax(
             int count)
         {
@@ -262,12 +262,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -285,12 +285,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void Max_WithComparer_ForCollectionWithSomeItems_ShouldReturnMax(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void Max_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void Max_WithComparer_ForCollectionWithSomeItems_ShouldReturnMax(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void Max_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MaxForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void Max_WithComparer_ForCollectionWithSomeItems_ShouldReturnMax(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void Max_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
@@ -213,12 +213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -236,12 +236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -261,12 +261,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -284,12 +284,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
@@ -213,12 +213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -236,12 +236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -261,12 +261,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -284,12 +284,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinByKeyTests.cs
@@ -213,12 +213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -236,12 +236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMin(
             int count)
         {
@@ -261,12 +261,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -284,12 +284,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void Min_WithComparer_ForCollectionWithSomeItems_ShouldReturnMin(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void Min_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void Min_WithComparer_ForCollectionWithSomeItems_ShouldReturnMin(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void Min_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinForGenericTypesWithComparerTests.cs
@@ -99,12 +99,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void Min_WithComparer_ForCollectionWithSomeItems_ShouldReturnMin(int count)
         {
             // Arrange.
@@ -119,12 +119,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void Min_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
@@ -220,12 +220,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -245,12 +245,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -272,12 +272,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -295,12 +295,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
@@ -220,12 +220,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -245,12 +245,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -272,12 +272,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -295,12 +295,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxByKeyTests.cs
@@ -220,12 +220,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -245,12 +245,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMaxBy_WithComparer_ForCollectionWithSomeItems_ShouldReturnProperMinMax(
             int count)
         {
@@ -272,12 +272,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMaxBy_WithoutComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {
@@ -295,12 +295,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMaxBy_WithComparer_ForCollectionWithTheSameItems_ShouldReturnThatItem(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
@@ -138,12 +138,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -163,12 +163,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -406,12 +406,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -432,12 +432,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -675,12 +675,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -701,12 +701,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -944,12 +944,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -970,12 +970,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1213,12 +1213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1239,12 +1239,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1562,12 +1562,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1585,12 +1585,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_WithSelector_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
@@ -138,12 +138,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -163,12 +163,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -406,12 +406,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -432,12 +432,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -675,12 +675,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -701,12 +701,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -944,12 +944,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -970,12 +970,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1213,12 +1213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1239,12 +1239,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1562,12 +1562,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1585,12 +1585,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_WithSelector_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithSelectorTests.cs
@@ -138,12 +138,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -163,12 +163,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -406,12 +406,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -432,12 +432,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -675,12 +675,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -701,12 +701,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -944,12 +944,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -970,12 +970,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1213,12 +1213,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1239,12 +1239,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1562,12 +1562,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1585,12 +1585,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_WithSelector_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
@@ -102,12 +102,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -123,12 +123,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -313,12 +313,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -335,12 +335,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -525,12 +525,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -547,12 +547,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -737,12 +737,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -759,12 +759,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -949,12 +949,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -971,12 +971,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1236,12 +1236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1259,12 +1259,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void MinMax_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
@@ -102,12 +102,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -123,12 +123,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -313,12 +313,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -335,12 +335,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -525,12 +525,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -547,12 +547,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -737,12 +737,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -759,12 +759,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -949,12 +949,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -971,12 +971,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1236,12 +1236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1259,12 +1259,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void MinMax_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/MinMaxWithoutSelectorTests.cs
@@ -102,12 +102,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_Int32_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -123,12 +123,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_NullableInt32_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -313,12 +313,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_Int64_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -335,12 +335,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_NullableInt64_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -525,12 +525,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_Single_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -547,12 +547,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_NullableSingle_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -737,12 +737,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_Double_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -759,12 +759,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_NullableDouble_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -949,12 +949,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_Decimal_ForCollectionWithSomeItems_ShouldReturnMinMax(int count)
         {
             // Arrange.
@@ -971,12 +971,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_NullableDecimal_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1236,12 +1236,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_GenericTypes_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {
@@ -1259,12 +1259,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void MinMax_GenericTypes_WithComparer_ForCollectionWithSomeItems_ShouldReturnMinMax(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
@@ -90,7 +90,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(Consts._1);
+                TestDataCreator.CreateRandomInt32List(TestConstants._1);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -105,7 +105,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(Consts._1);
+                TestDataCreator.CreateRandomInt32List(TestConstants._1);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -161,11 +161,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void SingleOrDefault_ForCollectionWithSomeItems_ShouldFail(int count)
         {
             // Arrange.
@@ -179,11 +179,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldFailIfFoundTwoAndMoreItmsAccordingToPredicate(
             int count)
         {
@@ -198,12 +198,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItemIfFoundNoItemsAccordingToPredicate(
             int count)
         {
@@ -301,7 +301,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
             // Arrange.
             var collection = new[] { 1, 2, 3, 4 };
             var explosiveCollection = ExplosiveCollection.Create(
-                collection, explosiveIndex: Constants.FirstIndex + 2
+                collection, explosiveIndex: Common.Constants.FirstIndex + 2
             );
 
             // Act & Assert.

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
@@ -90,7 +90,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(TestHelper.OneCollectionSize);
+                TestDataCreator.CreateRandomInt32List(TestHelper.One);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -105,7 +105,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(TestHelper.OneCollectionSize);
+                TestDataCreator.CreateRandomInt32List(TestHelper.One);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -161,11 +161,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void SingleOrDefault_ForCollectionWithSomeItems_ShouldFail(int count)
         {
             // Arrange.
@@ -179,11 +179,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldFailIfFoundTwoAndMoreItmsAccordingToPredicate(
             int count)
         {
@@ -198,12 +198,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItemIfFoundNoItemsAccordingToPredicate(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/SingleOrDefaultTests.cs
@@ -90,7 +90,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(TestHelper.One);
+                TestDataCreator.CreateRandomInt32List(Consts._1);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -105,7 +105,7 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         {
             // Arrange.
             IEnumerable<int> collectionWithSingleItem =
-                TestDataCreator.CreateRandomInt32List(TestHelper.One);
+                TestDataCreator.CreateRandomInt32List(Consts._1);
             int expectedValue = collectionWithSingleItem.Single();
 
             // Act.
@@ -161,11 +161,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void SingleOrDefault_ForCollectionWithSomeItems_ShouldFail(int count)
         {
             // Arrange.
@@ -179,11 +179,11 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldFailIfFoundTwoAndMoreItmsAccordingToPredicate(
             int count)
         {
@@ -198,12 +198,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void SingleOrDefault_WithPredicate_ForCollectionWithSomeItems_ShouldReturnDefaultItemIfFoundNoItemsAccordingToPredicate(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
@@ -392,12 +392,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyDictionary_WithKeySelector_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -419,12 +419,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyDictionary_WithKeySelectorAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -448,12 +448,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyDictionary_WithKeyElementSelectors_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -477,12 +477,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyDictionary_WithKeyElementSelectorsAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -854,12 +854,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyList_ForCollectionWithSomeItems_ShouldReturnFilledList(int count)
         {
             // Arrange.
@@ -983,12 +983,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToReadOnlyCollection_ForCollectionWithSomeItems_ShouldReturnFilledCollection(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
@@ -392,12 +392,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyDictionary_WithKeySelector_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -419,12 +419,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyDictionary_WithKeySelectorAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -448,12 +448,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyDictionary_WithKeyElementSelectors_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -477,12 +477,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyDictionary_WithKeyElementSelectorsAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -854,12 +854,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyList_ForCollectionWithSomeItems_ShouldReturnFilledList(int count)
         {
             // Arrange.
@@ -983,12 +983,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToReadOnlyCollection_ForCollectionWithSomeItems_ShouldReturnFilledCollection(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToReadOnlyCollectionsTests.cs
@@ -392,12 +392,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyDictionary_WithKeySelector_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -419,12 +419,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyDictionary_WithKeySelectorAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -448,12 +448,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyDictionary_WithKeyElementSelectors_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -477,12 +477,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyDictionary_WithKeyElementSelectorsAndComparer_ForCollectionWithSomeItems_ShouldReturnFilledDictionary(
             int count)
         {
@@ -854,12 +854,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyList_ForCollectionWithSomeItems_ShouldReturnFilledList(int count)
         {
             // Arrange.
@@ -983,12 +983,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToReadOnlyCollection_ForCollectionWithSomeItems_ShouldReturnFilledCollection(
             int count)
         {

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
@@ -423,12 +423,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -445,12 +445,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_WithEmptyCollectionMessage_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -468,12 +468,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparator_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -493,12 +493,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_WithSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -515,12 +515,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -540,12 +540,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(Consts._1)]
-        [InlineData(Consts._2)]
-        [InlineData(Consts._5)]
-        [InlineData(Consts._10)]
-        [InlineData(Consts._100)]
-        [InlineData(Consts._10_000)]
+        [InlineData(TestConstants._1)]
+        [InlineData(TestConstants._2)]
+        [InlineData(TestConstants._5)]
+        [InlineData(TestConstants._10)]
+        [InlineData(TestConstants._100)]
+        [InlineData(TestConstants._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparatorAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
@@ -423,12 +423,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -445,12 +445,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_WithEmptyCollectionMessage_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -468,12 +468,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparator_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -493,12 +493,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_WithSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -515,12 +515,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -540,12 +540,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.One)]
-        [InlineData(TestHelper.Two)]
-        [InlineData(TestHelper.Five)]
-        [InlineData(TestHelper.Ten)]
-        [InlineData(TestHelper.Hundred)]
-        [InlineData(TestHelper.TenThousand)]
+        [InlineData(Consts._1)]
+        [InlineData(Consts._2)]
+        [InlineData(Consts._5)]
+        [InlineData(Consts._10)]
+        [InlineData(Consts._100)]
+        [InlineData(Consts._10_000)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparatorAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
+++ b/Acolyte.NET/Tests/Acolyte.CSharp.Tests/Collections/EnumerableExtensions/ToSingleStringTests.cs
@@ -423,12 +423,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -445,12 +445,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_WithEmptyCollectionMessage_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -468,12 +468,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparator_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -493,12 +493,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_WithSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -515,12 +515,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_WithEmptyCollectionMessageAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.
@@ -540,12 +540,12 @@ namespace Acolyte.Tests.Collections.EnumerableExtensions
         }
 
         [Theory]
-        [InlineData(TestHelper.OneCollectionSize)]
-        [InlineData(TestHelper.TwoCollectionSize)]
-        [InlineData(TestHelper.FiveCollectionSie)]
-        [InlineData(TestHelper.TenCollectionSize)]
-        [InlineData(TestHelper.HundredCollectionSize)]
-        [InlineData(TestHelper.TenThousandCollectionSize)]
+        [InlineData(TestHelper.One)]
+        [InlineData(TestHelper.Two)]
+        [InlineData(TestHelper.Five)]
+        [InlineData(TestHelper.Ten)]
+        [InlineData(TestHelper.Hundred)]
+        [InlineData(TestHelper.TenThousand)]
         public void ToSingleString_WithEmptyCollectionMessageAndSeparatorAndSelector_ForCollectionWithSomeItems_ShouldReturnPropperMessageWithItems(int count)
         {
             // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.FSharp.Tests/Functional/SeqExTests.fs
+++ b/Acolyte.NET/Tests/Acolyte.FSharp.Tests/Functional/SeqExTests.fs
@@ -15,13 +15,13 @@ let ``"skipSafe" throw an exception if argument is null`` () =
     raises<ArgumentNullException> <@ SeqEx.skipSafe Unchecked.defaultof<int> null @>
 
 [<Theory>]
-[<InlineData(TestHelper.Zero)>]
-[<InlineData(TestHelper.NegativeOne)>]
-[<InlineData(TestHelper.NegativeTwo)>]
-[<InlineData(TestHelper.NegativeFive)>]
-[<InlineData(TestHelper.NegativeTen)>]
-[<InlineData(TestHelper.NegativeHundred)>]
-[<InlineData(TestHelper.NegativeTenThousand)>]
+[<InlineData(TestConstants._0)>]
+[<InlineData(TestConstants.Negative_1)>]
+[<InlineData(TestConstants.Negative_2)>]
+[<InlineData(TestConstants.Negative_5)>]
+[<InlineData(TestConstants.Negative_10)>]
+[<InlineData(TestConstants.Negative_100)>]
+[<InlineData(TestConstants.Negative_10_000)>]
 let ``"skipSafe" does not skip any items if "count" parameter is not positive``
     (count: int32) =
     // Arrange.
@@ -38,12 +38,12 @@ let ``"skipSafe" does not skip any items if "count" parameter is not positive``
     Assert.Equal<seq<int>>(expectedSeq, actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.One)>]
-[<InlineData(TestHelper.Two)>]
-[<InlineData(TestHelper.Five)>]
-[<InlineData(TestHelper.Ten)>]
-[<InlineData(TestHelper.Hundred)>]
-[<InlineData(TestHelper.TenThousand)>]
+[<InlineData(TestConstants._1)>]
+[<InlineData(TestConstants._2)>]
+[<InlineData(TestConstants._5)>]
+[<InlineData(TestConstants._10)>]
+[<InlineData(TestConstants._100)>]
+[<InlineData(TestConstants._10_000)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is less than collection length``
     (count: int32) =
     // Arrange.
@@ -65,12 +65,12 @@ let ``"skipSafe" can skip specified number of items if "count" parameter is less
     Assert.Equal<seq<int>>(expectedSeq, actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.One)>]
-[<InlineData(TestHelper.Two)>]
-[<InlineData(TestHelper.Five)>]
-[<InlineData(TestHelper.Ten)>]
-[<InlineData(TestHelper.Hundred)>]
-[<InlineData(TestHelper.TenThousand)>]
+[<InlineData(TestConstants._1)>]
+[<InlineData(TestConstants._2)>]
+[<InlineData(TestConstants._5)>]
+[<InlineData(TestConstants._10)>]
+[<InlineData(TestConstants._100)>]
+[<InlineData(TestConstants._10_000)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is equal to collection length``
     (count: int32) =
     // Arrange.
@@ -87,12 +87,12 @@ let ``"skipSafe" can skip specified number of items if "count" parameter is equa
     Assert.Empty(actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.One)>]
-[<InlineData(TestHelper.Two)>]
-[<InlineData(TestHelper.Five)>]
-[<InlineData(TestHelper.Ten)>]
-[<InlineData(TestHelper.Hundred)>]
-[<InlineData(TestHelper.TenThousand)>]
+[<InlineData(TestConstants._1)>]
+[<InlineData(TestConstants._2)>]
+[<InlineData(TestConstants._5)>]
+[<InlineData(TestConstants._10)>]
+[<InlineData(TestConstants._100)>]
+[<InlineData(TestConstants._10_000)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is greater than collection length``
     (count: int32) =
     // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.FSharp.Tests/Functional/SeqExTests.fs
+++ b/Acolyte.NET/Tests/Acolyte.FSharp.Tests/Functional/SeqExTests.fs
@@ -15,13 +15,13 @@ let ``"skipSafe" throw an exception if argument is null`` () =
     raises<ArgumentNullException> <@ SeqEx.skipSafe Unchecked.defaultof<int> null @>
 
 [<Theory>]
-[<InlineData(TestHelper.ZeroCollectionSize)>]
-[<InlineData(TestHelper.NegativeOneCollectionSize)>]
-[<InlineData(TestHelper.NegativeTwoCollectionSize)>]
-[<InlineData(TestHelper.NegativeFiveCollectionSie)>]
-[<InlineData(TestHelper.NegativeTenCollectionSize)>]
-[<InlineData(TestHelper.NegativeHundredCollectionSize)>]
-[<InlineData(TestHelper.NegativeTenThousandCollectionSize)>]
+[<InlineData(TestHelper.Zero)>]
+[<InlineData(TestHelper.NegativeOne)>]
+[<InlineData(TestHelper.NegativeTwo)>]
+[<InlineData(TestHelper.NegativeFive)>]
+[<InlineData(TestHelper.NegativeTen)>]
+[<InlineData(TestHelper.NegativeHundred)>]
+[<InlineData(TestHelper.NegativeTenThousand)>]
 let ``"skipSafe" does not skip any items if "count" parameter is not positive``
     (count: int32) =
     // Arrange.
@@ -38,12 +38,12 @@ let ``"skipSafe" does not skip any items if "count" parameter is not positive``
     Assert.Equal<seq<int>>(expectedSeq, actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.OneCollectionSize)>]
-[<InlineData(TestHelper.TwoCollectionSize)>]
-[<InlineData(TestHelper.FiveCollectionSie)>]
-[<InlineData(TestHelper.TenCollectionSize)>]
-[<InlineData(TestHelper.HundredCollectionSize)>]
-[<InlineData(TestHelper.TenThousandCollectionSize)>]
+[<InlineData(TestHelper.One)>]
+[<InlineData(TestHelper.Two)>]
+[<InlineData(TestHelper.Five)>]
+[<InlineData(TestHelper.Ten)>]
+[<InlineData(TestHelper.Hundred)>]
+[<InlineData(TestHelper.TenThousand)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is less than collection length``
     (count: int32) =
     // Arrange.
@@ -65,12 +65,12 @@ let ``"skipSafe" can skip specified number of items if "count" parameter is less
     Assert.Equal<seq<int>>(expectedSeq, actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.OneCollectionSize)>]
-[<InlineData(TestHelper.TwoCollectionSize)>]
-[<InlineData(TestHelper.FiveCollectionSie)>]
-[<InlineData(TestHelper.TenCollectionSize)>]
-[<InlineData(TestHelper.HundredCollectionSize)>]
-[<InlineData(TestHelper.TenThousandCollectionSize)>]
+[<InlineData(TestHelper.One)>]
+[<InlineData(TestHelper.Two)>]
+[<InlineData(TestHelper.Five)>]
+[<InlineData(TestHelper.Ten)>]
+[<InlineData(TestHelper.Hundred)>]
+[<InlineData(TestHelper.TenThousand)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is equal to collection length``
     (count: int32) =
     // Arrange.
@@ -87,12 +87,12 @@ let ``"skipSafe" can skip specified number of items if "count" parameter is equa
     Assert.Empty(actualSeq)
 
 [<Theory>]
-[<InlineData(TestHelper.OneCollectionSize)>]
-[<InlineData(TestHelper.TwoCollectionSize)>]
-[<InlineData(TestHelper.FiveCollectionSie)>]
-[<InlineData(TestHelper.TenCollectionSize)>]
-[<InlineData(TestHelper.HundredCollectionSize)>]
-[<InlineData(TestHelper.TenThousandCollectionSize)>]
+[<InlineData(TestHelper.One)>]
+[<InlineData(TestHelper.Two)>]
+[<InlineData(TestHelper.Five)>]
+[<InlineData(TestHelper.Ten)>]
+[<InlineData(TestHelper.Hundred)>]
+[<InlineData(TestHelper.TenThousand)>]
 let ``"skipSafe" can skip specified number of items if "count" parameter is greater than collection length``
     (count: int32) =
     // Arrange.

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveCollection.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveCollection.cs
@@ -22,7 +22,7 @@ namespace Acolyte.Tests.Collections
         {
             _originalCollection = originalCollection.ThrowIfNull(nameof(originalCollection));
             _explosiveIndex = explosiveIndex.ThrowIfValueIsOutOfRange(
-                nameof(explosiveIndex), Constants.NotFoundIndex, int.MaxValue
+                nameof(explosiveIndex), Common.Constants.NotFoundIndex, int.MaxValue
             );
 
             _visitedItemsNumber = new CounterInt32();
@@ -68,7 +68,7 @@ namespace Acolyte.Tests.Collections
         {
             return new ExplosiveCollection<T>(
                 originalCollection: originalCollection,
-                explosiveIndex: Constants.NotFoundIndex
+                explosiveIndex: Common.Constants.NotFoundIndex
             );
         }
     }

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveCollection.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Acolyte.Assertions;
 using Acolyte.Common;
+using Acolyte.Threading;
 
 namespace Acolyte.Tests.Collections
 {

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveEnumerator.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveEnumerator.cs
@@ -27,7 +27,7 @@ namespace Acolyte.Tests.Collections
         {
             _originalEnumerator = originalEnumerator.ThrowIfNull(nameof(originalEnumerator));
             _explosiveIndex = explosiveIndex.ThrowIfValueIsOutOfRange(
-                nameof(explosiveIndex), Constants.NotFoundIndex, int.MaxValue
+                nameof(explosiveIndex), Common.Constants.NotFoundIndex, int.MaxValue
             );
             _visitedItemsNumber = visitedItemsNumber.ThrowIfNull(nameof(visitedItemsNumber));
 

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveEnumerator.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Collections/ExplosiveEnumerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Acolyte.Assertions;
 using Acolyte.Common;
 using Acolyte.Tests.Exceptions;
+using Acolyte.Threading;
 
 namespace Acolyte.Tests.Collections
 {

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Creators/TestDataCreator.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Creators/TestDataCreator.cs
@@ -266,14 +266,14 @@ namespace Acolyte.Tests.Creators
         {
             random ??= RandomInstance;
 
-            return CreateRandomNonNegativeInt32(TestHelper.HundredCollectionSize, random);
+            return CreateRandomNonNegativeInt32(TestHelper.Hundred, random);
         }
 
         public static int GetRandomPositiveSmallCountNumber(Random? random = null)
         {
             random ??= RandomInstance;
 
-            return CreateRandomPositiveInt32(TestHelper.HundredCollectionSize, random);
+            return CreateRandomPositiveInt32(TestHelper.Hundred, random);
         }
 
         #endregion

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/Creators/TestDataCreator.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/Creators/TestDataCreator.cs
@@ -252,28 +252,28 @@ namespace Acolyte.Tests.Creators
         {
             random ??= RandomInstance;
 
-            return CreateRandomNonNegativeInt32(TestHelper.MaxCollectionSize, random);
+            return CreateRandomNonNegativeInt32(TestConstants.MaxCollectionSize, random);
         }
 
         public static int GetRandomPositiveCountNumber(Random? random = null)
         {
             random ??= RandomInstance;
 
-            return CreateRandomPositiveInt32(TestHelper.MaxCollectionSize, random);
+            return CreateRandomPositiveInt32(TestConstants.MaxCollectionSize, random);
         }
 
         public static int GetRandomSmallCountNumber(Random? random = null)
         {
             random ??= RandomInstance;
 
-            return CreateRandomNonNegativeInt32(TestHelper.Hundred, random);
+            return CreateRandomNonNegativeInt32(TestConstants._100, random);
         }
 
         public static int GetRandomPositiveSmallCountNumber(Random? random = null)
         {
             random ??= RandomInstance;
 
-            return CreateRandomPositiveInt32(TestHelper.Hundred, random);
+            return CreateRandomPositiveInt32(TestConstants._100, random);
         }
 
         #endregion

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
@@ -1,6 +1,6 @@
 ﻿namespace Acolyte.Tests
 {
-    public static class Consts
+    public static class TestConstants
 
     {
         // Max collection size in C# is equal to 2_146_435_071 but we do not need such large values.

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
@@ -1,35 +1,36 @@
 ﻿namespace Acolyte.Tests
 {
-    public static class TestHelper
+    public static class Consts
+
     {
         // Max collection size in C# is equal to 2_146_435_071 but we do not need such large values.
         public const int NegativeMaxCollectionSize = -MaxCollectionSize;
 
-        public const int NegativeTenThousand = -TenThousand;
+        public const int Negative_10_000 = -_10_000;
 
-        public const int NegativeHundred = -Hundred;
+        public const int Negative_100 = -_100;
 
-        public const int NegativeTen = -Ten;
+        public const int Negative_10 = -_10;
 
-        public const int NegativeFive = -Five;
+        public const int Negative_5 = -_5;
 
-        public const int NegativeTwo = -Two;
+        public const int Negative_2 = -_2;
 
-        public const int NegativeOne = -One;
+        public const int Negative_1 = -_1;
 
-        public const int Zero = 0;
+        public const int _0 = 0;
 
-        public const int One = 1;
+        public const int _1 = 1;
 
-        public const int Two = 2;
+        public const int _2 = 2;
 
-        public const int Five = 5;
+        public const int _5 = 5;
 
-        public const int Ten = 10;
+        public const int _10 = 10;
 
-        public const int Hundred = 100;
+        public const int _100 = 100;
 
-        public const int TenThousand = 10_000;
+        public const int _10_000 = 10_000;
 
         // Max collection size in C# is equal to 2_146_435_071 but we do not need such large values.
         public const int MaxCollectionSize = 2_146_435;

--- a/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
+++ b/Acolyte.NET/Tests/Acolyte.Tests.Common/TestHelper.cs
@@ -5,31 +5,31 @@
         // Max collection size in C# is equal to 2_146_435_071 but we do not need such large values.
         public const int NegativeMaxCollectionSize = -MaxCollectionSize;
 
-        public const int NegativeTenThousandCollectionSize = -TenThousandCollectionSize;
+        public const int NegativeTenThousand = -TenThousand;
 
-        public const int NegativeHundredCollectionSize = -HundredCollectionSize;
+        public const int NegativeHundred = -Hundred;
 
-        public const int NegativeTenCollectionSize = -TenCollectionSize;
+        public const int NegativeTen = -Ten;
 
-        public const int NegativeFiveCollectionSie = -FiveCollectionSie;
+        public const int NegativeFive = -Five;
 
-        public const int NegativeTwoCollectionSize = -TwoCollectionSize;
+        public const int NegativeTwo = -Two;
 
-        public const int NegativeOneCollectionSize = -OneCollectionSize;
+        public const int NegativeOne = -One;
 
-        public const int ZeroCollectionSize = 0;
+        public const int Zero = 0;
 
-        public const int OneCollectionSize = 1;
+        public const int One = 1;
 
-        public const int TwoCollectionSize = 2;
+        public const int Two = 2;
 
-        public const int FiveCollectionSie = 5;
+        public const int Five = 5;
 
-        public const int TenCollectionSize = 10;
+        public const int Ten = 10;
 
-        public const int HundredCollectionSize = 100;
+        public const int Hundred = 100;
 
-        public const int TenThousandCollectionSize = 10_000;
+        public const int TenThousand = 10_000;
 
         // Max collection size in C# is equal to 2_146_435_071 but we do not need such large values.
         public const int MaxCollectionSize = 2_146_435;

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Acolyte.Assertions;
 using Acolyte.Collections;
+using Acolyte.Common;
 using Acolyte.Threading;
 
 namespace Acolyte.Examples
@@ -127,7 +128,8 @@ namespace Acolyte.Examples
                 nameof(count), includedLowerBound: 1, includedUpperBound: 1000
             );
 
-            return Enumerable.Range(0, count)
+            return Enumerable
+                .Range(0, count)
                 .Select(_ => generator());
         }
 
@@ -137,15 +139,14 @@ namespace Acolyte.Examples
             source.ThrowIfNull(nameof(source));
             pattern.ThrowIfNullOrEmpty(nameof(pattern));
 
-            return source
-                .Where(item => Regex.IsMatch(item, pattern));
+            return source.Where(item => Regex.IsMatch(item, pattern));
         }
 
         internal static void OutputCollection<T>(IEnumerable<T> collection)
         {
             collection.ThrowIfNull(nameof(collection));
 
-            Console.WriteLine($"Collection: [{collection.EnumerableToOneString()}].");
+            Console.WriteLine($"Collection: [{collection.ToSingleString()}].");
         }
 
         internal static int DistanceBetweenMinAndMax(IEnumerable<int> source)
@@ -158,15 +159,15 @@ namespace Acolyte.Examples
 
         internal static async Task ExecuteAllTasksSafe(params Task[] tasks)
         {
-            IReadOnlyList<ResultOrException<NoneResult>> resultObjects =
+            IReadOnlyList<Result<NoneResult, Exception>> resultObjects =
                 await TaskHelper.WhenAllResultsOrExceptions(tasks);
 
             IReadOnlyList<Exception> exceptions = resultObjects.UnwrapResultsOrExceptions();
 
             string separator = Environment.NewLine;
             const string emptyCollectionMessage = "No exceptions occurred.";
-            string exceptionsToLog = exceptions.EnumerableToOneString(
-                separator, emptyCollectionMessage, selector: ex => ex.ToString()
+            string exceptionsToLog = exceptions.ToSingleString(
+                emptyCollectionMessage, separator, selector: ex => ex.ToString()
             );
 
             Console.WriteLine($"{separator}{exceptionsToLog}{separator}");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.0.0.{build}'
+version: '2.1.0.{build}'
 image: Visual Studio 2019
 
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ shallow_clone: true
 dotnet_csproj:
   patch: true
   file: '**\*.csproj;**\*.fsproj'
-  assembly_version: '{version}'
-  file_version: '{version}'
+  assembly_version: '{packageVersion}'
+  file_version: '{packageVersion}'
   version: '$(packageVersion)'
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,12 @@ artifacts:
 before_deploy:
   - dotnet pack --configuration Release --no-build "../Acolyte.NET"
 
+# 1. Regenerate AppVeyor Api Key
+# https://www.nuget.org/account/apikeys
+# 2. Encrypt configuration data
+# https://ci.appveyor.com/tools/encrypt
+# 3. Paste below
+
 # Deploy from master branch only.
 deploy:
   # Deploy to NuGet repository.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ shallow_clone: true
 dotnet_csproj:
   patch: true
   file: '**\*.csproj;**\*.fsproj'
-  assembly_version: '{packageVersion}'
-  file_version: '{packageVersion}'
+  assembly_version: '$(packageVersion)'
+  file_version: '$(packageVersion)'
   version: '$(packageVersion)'
 
 branches:


### PR DESCRIPTION
# Release v2.1.0
Quick fixes of some issues and updates for configuration. Unfortunately, some public API were changed (see BREAKING CHANGES section). Full list of changes you can find bellow.

## Configuration changes
- Added dependbot config

## BREAKING CHANGES
- Fixed invalid namespace for counters: `Acolyte.Common.CounterInt32/64` => `Acolyte.Threading.CounterInt32/64`

## Major changes
- Used Microsoft.Bcl.HashCode instead of own HashCode implementation
- `Acolyte.Common.HashCode` marked as obsolete

## Bug fixes
- Fixed README samples

## Closing issues
- Closed #7 
